### PR TITLE
fix: handle missing symbolic ref

### DIFF
--- a/src/bin/hook-commands/pre-push.js
+++ b/src/bin/hook-commands/pre-push.js
@@ -35,7 +35,6 @@ async function getDefaultBranchFromRemote(remote) {
   const headRefs = await git('ls-remote', '--symref', remoteUrl, 'HEAD');
   const match = extractRef.exec(headRefs);
   if (!match) {
-    console.dir(headRefs);
     throw new Error('unable to interpret ls-remote output');
   }
   return match[1];


### PR DESCRIPTION
The `refs/remotes/origin/HEAD` ref is only configured when `git clone` was used on a non-empty repository - this isn't always the case, and it's undesirable to break in that rare case.