### PR TITLE
fix(commit-msg): use correct name for command invocation

### DIFF
--- a/src/bin/hook-commands/commit-msg.js
+++ b/src/bin/hook-commands/commit-msg.js
@@ -6,7 +6,7 @@ import { promisify } from 'util';
 const readFile = promisify(fs.readFile);
 
 export default {
-  command: '$0',
+  command: 'commit-msg',
   description: 'Check the commit message',
   async handler() {
     if (!(await expectEnabled('commit-msg'))) return;


### PR DESCRIPTION
Discovered in https://github.com/mixmaxhq/source-tracking/pull/320