### PR TITLE
feat: make this module public (reminder: see Release Plan before merging)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,11 @@
-Jira:
-
 #### Changes Made
 
 #### Potential Risks
-<!--- What can go wrong with this deploy? Does it touch any critical services? How will these changes affect adjacent code/features? How will we handle any adverse issues? Have you posted those steps in #eng-alerts if this has safety belts/steps?--->
+<!--- What can go wrong with this change? How will these changes affect adjacent code/features? How will we handle any adverse issues? --->
 
 #### Test Plan
-<!--- What steps do you take to ensure that this PR does what it's supposed to do? How do you ensure that adjacent code/features are still working as predicted? --->
-
-#### Release Plan
-<!-- Add any tasks that need to be done before/during/after release beyond creating and merging the deploy PR: creating indices, deploying other services, bumping modules, etc. -->
+<!--- How do we know this PR does what it's supposed to do? How do we ensure that adjacent code/features are still working? How do we evaluate the performance implications of this PR?--->
 
 #### Checklist
 - [ ] I've increased test coverage
-- [ ] I've enabled Flow in the files I've touched
-- [ ] I'm using ODM for database calls
-- [ ] Should this involve a live code review and/or demo?
+- [ ] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Mixmax, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "Eli Skeggs <eli@mixmax.com> (https://mixmax.com)",
     "Enric Ribas <enric@mixmax.com> (https://mixmax.com)"
   ],
-  "license": "UNLICENSED",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/mixmaxhq/git-hooks/issues"
   },
@@ -76,6 +76,6 @@
     "extends": "@mixmaxhq/semantic-release-config"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }


### PR DESCRIPTION
Jira: none. Discussed in https://github.com/mixmaxhq/commitlint-jenkins/pull/189

#### Changes Made
Makes this module public so we can continue to use it inside our open source projects.

#### Potential Risks
That we're leaking something secret. Unlikely since a review of all the code files doesn't reveal anything internal or sensitive.

That I'm missing a step when converting this to public. However, this was forked from @mixmaxhq/template-module and step 5 in its readme specifically mentions what to change to make a module public: https://github.com/mixmaxhq/template-module

#### Test Plan
None.

#### Release Plan
- [ ] Uncheck 'private' here https://www.npmjs.com/package/@mixmaxhq/git-hooks/access
- [ ] Merge this PR and let it build
- [ ] Ensure https://www.npmjs.com/package/@mixmaxhq/git-hooks still says 'public'
- [ ] Change github settings to make this repo public https://github.com/mixmaxhq/git-hooks/settings